### PR TITLE
Make notification icon optional

### DIFF
--- a/notification/notification.go
+++ b/notification/notification.go
@@ -44,7 +44,11 @@ func Add(id uint, content Content) error {
 	data := map[string]dbus.Variant{
 		"title": convert.FromString(content.Title),
 		"body":  convert.FromString(content.Body),
-		"icon":  convert.FromString(content.Icon),
+	}
+
+	// Only add the icon field when it is set
+	if content.Icon != "" {
+		data["icon"] = convert.FromString(content.Icon)
 	}
 
 	// Only add the priority field when it is set.


### PR DESCRIPTION
### Description:
Title, body, and icon should all be optional. Setting no icon currently results in broken notifications such as:
![image](https://github.com/rymdport/portal/assets/11866552/2cfa3e12-4fce-4a43-a67e-585d334e3043)

This PR fixes that by making the icon optional.
![image](https://github.com/rymdport/portal/assets/11866552/660af72a-3851-4475-84a8-8c6972c7a9aa)
