### PR TITLE
Avoid trying to autostart settings handler

### DIFF
--- a/settings/read.go
+++ b/settings/read.go
@@ -21,7 +21,7 @@ func ReadAll(namespaces []string) (map[string](map[string]dbus.Variant), error) 
 	}
 
 	obj := conn.Object(apis.ObjectName, apis.ObjectPath)
-	call := obj.Call(readAllCallPath, 0, namespaces)
+	call := obj.Call(readAllCallPath, dbus.FlagNoAutoStart, namespaces)
 	if call.Err != nil {
 		return nil, call.Err
 	}
@@ -48,7 +48,7 @@ func read(callPath, namespace, key string) (any, error) {
 	}
 
 	obj := conn.Object(apis.ObjectName, apis.ObjectPath)
-	call := obj.Call(callPath, 0, namespace, key)
+	call := obj.Call(callPath, dbus.FlagNoAutoStart, namespace, key)
 	if call.Err != nil {
 		return nil, call.Err
 	}


### PR DESCRIPTION
### Description:
<!-- A description of the included change. Please include any relevant motivation and background.
If it fixes an issue, please add a line with: Fixes #issue-number -->

An idea to hopefully fix portal settings lookups hanging for desktops that don't support the spec.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.