### PR TITLE
Fix Request.Response signal race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The version of this module's API is still in a `v0.X.Y` state and is subject to change in the future.
 A release with breaking changes will increment X while Y will be incremented when there are minor bug or feature improvements.
 
+## v0.5.0 (unreleased)
+
+- Fix a race between the portal method reply and the `Request.Response` signal that caused intermittent `ErrUnexpectedResponse` or hangs on fast backends (COSMIC, Hyprland). The `Response` subscription is now installed before the method call, using the deterministic Request path from the spec.
+- Add `*Context` variants for every portal call that returns a `Request` handle. Cancelling the context dismisses the portal dialog on a best-effort basis. Existing functions keep their signatures.
+- Fix `screenshot.PickColor` and `(*location.Session).Start` silently ignoring `HandleToken`: they were sending `handleToken` and `HandleToken` instead of `handle_token`.
+- Internal: add a shared signal router so every caller receives only the signals matching its `(path, interface.member)`, and listener channels are no longer leaked.
+- `(*location.Session).Close` and `(*usb.Session).Close` now stop the listener goroutines set up by `SetOnClosed`, `SetOnLocationUpdated` and `SetOnDeviceEvents`.
+
 ## v0.4.0
 
 - Rename the `Writeable` field in `openuri.OpenURIOptions` to `Writable` to fix spelling error.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ func main() {
 }
 ```
 
+Every function that opens a portal dialog has a `*Context` variant. Cancelling the context asks the portal to dismiss the dialog:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+
+files, err := filechooser.OpenFileContext(ctx, "", "Select files", nil)
+if errors.Is(err, context.DeadlineExceeded) {
+	// user did not pick a file within 30s; dialog was dismissed
+}
+```
+
 ## Supported Portal Interfaces
 
 The list below contains all of the portal interfaces available within the project. Checked boxes are partially or completely implemented within this project. Note that this list usually refers to the state of the `main` branch and not necessarily the latest release.

--- a/account/userinfo.go
+++ b/account/userinfo.go
@@ -1,8 +1,9 @@
 package account
 
 import (
+	"context"
+
 	"github.com/godbus/dbus/v5"
-	"github.com/rymdport/portal/internal/apis"
 	"github.com/rymdport/portal/internal/convert"
 	"github.com/rymdport/portal/internal/request"
 )
@@ -25,32 +26,34 @@ type UserInfoResult struct {
 // GetUserInformation gets information about the current user.
 // Both return values will be nil if the user cancelled the request.
 func GetUserInformation(parentWindow string, options *UserInfoOptions) (*UserInfoResult, error) {
-	data := map[string]dbus.Variant{}
-	if options != nil {
-		if options.HandleToken != "" {
-			data["handle_token"] = convert.FromString(options.HandleToken)
-		}
+	return GetUserInformationContext(context.Background(), parentWindow, options)
+}
 
-		if options.Reason != "" {
+// GetUserInformationContext is GetUserInformation with a context.
+func GetUserInformationContext(ctx context.Context, parentWindow string, options *UserInfoOptions) (*UserInfoResult, error) {
+	userToken := ""
+	if options != nil {
+		userToken = options.HandleToken
+	}
+
+	resp, err := request.SendRequest(ctx, userToken, getUserInfoCallName, func(token string) []any {
+		data := map[string]dbus.Variant{
+			"handle_token": convert.FromString(token),
+		}
+		if options != nil && options.Reason != "" {
 			data["reason"] = convert.FromString(options.Reason)
 		}
-	}
-
-	result, err := apis.Call(getUserInfoCallName, parentWindow, data)
+		return []any{parentWindow, data}
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	status, results, err := request.OnSignalResponse(result.(dbus.ObjectPath))
-	if err != nil {
-		return nil, err
-	} else if status == request.Cancelled {
+	} else if resp.Status == request.Cancelled {
 		return nil, nil
 	}
 
-	id := results["id"].Value().(string)
-	name := results["name"].Value().(string)
-	image := results["image"].Value().(string)
+	id, _ := resp.Results["id"].Value().(string)
+	name, _ := resp.Results["name"].Value().(string)
+	image, _ := resp.Results["image"].Value().(string)
 	return &UserInfoResult{
 		Id:    id,
 		Name:  name,

--- a/background/request.go
+++ b/background/request.go
@@ -1,8 +1,9 @@
 package background
 
 import (
+	"context"
+
 	"github.com/godbus/dbus/v5"
-	"github.com/rymdport/portal/internal/apis"
 	"github.com/rymdport/portal/internal/convert"
 	"github.com/rymdport/portal/internal/request"
 )
@@ -26,37 +27,41 @@ type RequestResult struct {
 
 // RequestBackground requests that the application is allowed to run in the background.
 func RequestBackground(parentWindow string, options *RequestOptions) (*RequestResult, error) {
-	data := map[string]dbus.Variant{}
+	return RequestBackgroundContext(context.Background(), parentWindow, options)
+}
+
+// RequestBackgroundContext is RequestBackground with a context.
+func RequestBackgroundContext(ctx context.Context, parentWindow string, options *RequestOptions) (*RequestResult, error) {
+	userToken := ""
 	if options != nil {
-		data["autostart"] = convert.FromBool(options.Autostart)
-		data["dbus-activatable"] = convert.FromBool(options.DbusActivatable)
-
-		if options.HandleToken != "" {
-			data["handle_token"] = convert.FromString(options.HandleToken)
-		}
-
-		if options.Reason != "" {
-			data["reason"] = convert.FromString(options.Reason)
-		}
-
-		if len(options.Commandline) != 0 {
-			data["commandline"] = dbus.MakeVariant(options.Commandline) // TODO: Might want to create fast converter for []string.
-		}
+		userToken = options.HandleToken
 	}
 
-	result, err := apis.Call(requestCallName, parentWindow, data)
-	if err != nil {
-		return nil, err
-	}
+	resp, err := request.SendRequest(ctx, userToken, requestCallName, func(token string) []any {
+		data := map[string]dbus.Variant{
+			"handle_token": convert.FromString(token),
+		}
+		if options != nil {
+			data["autostart"] = convert.FromBool(options.Autostart)
+			data["dbus-activatable"] = convert.FromBool(options.DbusActivatable)
 
-	status, results, err := request.OnSignalResponse(result.(dbus.ObjectPath))
+			if options.Reason != "" {
+				data["reason"] = convert.FromString(options.Reason)
+			}
+
+			if len(options.Commandline) != 0 {
+				data["commandline"] = dbus.MakeVariant(options.Commandline) // TODO: Might want to create fast converter for []string.
+			}
+		}
+		return []any{parentWindow, data}
+	})
 	if err != nil {
 		return nil, err
-	} else if status == request.Cancelled {
+	} else if resp.Status == request.Cancelled {
 		return nil, nil // Cancelled by user.
 	}
 
-	background := results["background"].Value().(bool)
-	autostart := results["autostart"].Value().(bool)
+	background, _ := resp.Results["background"].Value().(bool)
+	autostart, _ := resp.Results["autostart"].Value().(bool)
 	return &RequestResult{Background: background, Autostart: autostart}, nil
 }

--- a/filechooser/filechooser.go
+++ b/filechooser/filechooser.go
@@ -1,32 +1,39 @@
-// Package filechooser allows sandboxed applications to ask the user for access to files outside the sandbox. The portal backend will present the user with a file chooser dialog.
-// Upstream API documentation can be found at https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.FileChooser.html.
+// Package filechooser asks the user to pick files through the xdg-desktop-portal
+// FileChooser interface.
+//
+// https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.FileChooser.html
 package filechooser
 
 import (
+	"context"
 	"net/url"
 
-	"github.com/godbus/dbus/v5"
 	"github.com/rymdport/portal/internal/apis"
 	"github.com/rymdport/portal/internal/request"
 )
 
 const interfaceName = apis.CallBaseName + ".FileChooser"
 
-func readURIFromResponse(path dbus.ObjectPath) ([]string, error) {
-	status, results, err := request.OnSignalResponse(path)
+func callForURIs(ctx context.Context, token, callName string, buildArgs func(token string) []any) ([]string, error) {
+	resp, err := request.SendRequest(ctx, token, callName, buildArgs)
 	if err != nil {
 		return nil, err
-	} else if status == request.Cancelled {
+	}
+	if resp.Status == request.Cancelled {
 		return nil, nil
 	}
 
-	uris := results["uris"].Value().([]string)
-	for i, uri := range uris {
+	rawURIs, ok := resp.Results["uris"].Value().([]string)
+	if !ok {
+		return nil, nil
+	}
+
+	uris := make([]string, len(rawURIs))
+	for i, uri := range rawURIs {
 		uris[i], err = url.QueryUnescape(uri)
 		if err != nil {
 			return nil, err
 		}
 	}
-
 	return uris, nil
 }

--- a/filechooser/open.go
+++ b/filechooser/open.go
@@ -1,8 +1,9 @@
 package filechooser
 
 import (
+	"context"
+
 	"github.com/godbus/dbus/v5"
-	"github.com/rymdport/portal/internal/apis"
 	"github.com/rymdport/portal/internal/convert"
 )
 
@@ -24,41 +25,42 @@ type OpenFileOptions struct {
 // OpenFile opens a filechooser for selecting a file to open.
 // The chooser will use the supplied title as it's name.
 func OpenFile(parentWindow, title string, options *OpenFileOptions) ([]string, error) {
-	data := map[string]dbus.Variant{}
+	return OpenFileContext(context.Background(), parentWindow, title, options)
+}
+
+// OpenFileContext is OpenFile with a context.
+func OpenFileContext(ctx context.Context, parentWindow, title string, options *OpenFileOptions) ([]string, error) {
+	userToken := ""
 	if options != nil {
-		data["modal"] = convert.FromBool(!options.NotModal)
-		data["multiple"] = convert.FromBool(options.Multiple)
-		data["directory"] = convert.FromBool(options.Directory)
-
-		if options.HandleToken != "" {
-			data["handle_token"] = convert.FromString(options.HandleToken)
-		}
-
-		if options.AcceptLabel != "" {
-			data["accept_label"] = convert.FromString(options.AcceptLabel)
-		}
-
-		if len(options.Filters) > 0 {
-			data["filters"] = dbus.MakeVariant(options.Filters)
-		}
-
-		if options.CurrentFilter != nil {
-			data["current_filter"] = dbus.MakeVariant(options.CurrentFilter)
-		}
-
-		if len(options.Choices) > 0 {
-			data["choices"] = dbus.MakeVariant(options.Choices)
-		}
-
-		if options.CurrentFolder != "" {
-			data["current_folder"] = convert.ToNullTerminatedValue(options.CurrentFolder)
-		}
+		userToken = options.HandleToken
 	}
 
-	result, err := apis.Call(openFileCallName, parentWindow, title, data)
-	if err != nil {
-		return nil, err
-	}
+	return callForURIs(ctx, userToken, openFileCallName, func(token string) []any {
+		data := map[string]dbus.Variant{
+			"handle_token": convert.FromString(token),
+		}
+		if options != nil {
+			data["modal"] = convert.FromBool(!options.NotModal)
+			data["multiple"] = convert.FromBool(options.Multiple)
+			data["directory"] = convert.FromBool(options.Directory)
 
-	return readURIFromResponse(result.(dbus.ObjectPath))
+			if options.AcceptLabel != "" {
+				data["accept_label"] = convert.FromString(options.AcceptLabel)
+			}
+			if len(options.Filters) > 0 {
+				data["filters"] = dbus.MakeVariant(options.Filters)
+			}
+			if options.CurrentFilter != nil {
+				data["current_filter"] = dbus.MakeVariant(options.CurrentFilter)
+			}
+			if len(options.Choices) > 0 {
+				data["choices"] = dbus.MakeVariant(options.Choices)
+			}
+			if options.CurrentFolder != "" {
+				data["current_folder"] = convert.ToNullTerminatedValue(options.CurrentFolder)
+			}
+		}
+
+		return []any{parentWindow, title, data}
+	})
 }

--- a/filechooser/save.go
+++ b/filechooser/save.go
@@ -1,8 +1,9 @@
 package filechooser
 
 import (
+	"context"
+
 	"github.com/godbus/dbus/v5"
-	"github.com/rymdport/portal/internal/apis"
 	"github.com/rymdport/portal/internal/convert"
 )
 
@@ -26,45 +27,45 @@ type SaveFileOptions struct {
 // SaveFile opens a filechooser for selecting where to save a file.
 // The chooser will use the supplied title as it's name.
 func SaveFile(parentWindow, title string, options *SaveFileOptions) ([]string, error) {
-	data := map[string]dbus.Variant{}
+	return SaveFileContext(context.Background(), parentWindow, title, options)
+}
+
+// SaveFileContext is SaveFile with a context.
+func SaveFileContext(ctx context.Context, parentWindow, title string, options *SaveFileOptions) ([]string, error) {
+	userToken := ""
 	if options != nil {
-		data["modal"] = convert.FromBool(!options.NotModal)
-
-		if options.HandleToken != "" {
-			data["handle_token"] = convert.FromString(options.HandleToken)
-		}
-
-		if options.AcceptLabel != "" {
-			data["accept_label"] = convert.FromString(options.AcceptLabel)
-		}
-
-		if len(options.Filters) > 0 {
-			data["filters"] = dbus.MakeVariant(options.Filters)
-		}
-
-		if options.CurrentFilter != nil {
-			data["current_filter"] = dbus.MakeVariant(options.CurrentFilter)
-		}
-
-		if len(options.Choices) > 0 {
-			data["choices"] = dbus.MakeVariant(options.Choices)
-		}
-
-		if options.CurrentName != "" {
-			data["current_name"] = convert.FromString(options.CurrentName)
-		}
-
-		if options.CurrentFolder != "" {
-			data["current_folder"] = convert.ToNullTerminatedValue(options.CurrentFolder)
-		}
+		userToken = options.HandleToken
 	}
 
-	result, err := apis.Call(saveFileCallName, parentWindow, title, data)
-	if err != nil {
-		return nil, err
-	}
+	return callForURIs(ctx, userToken, saveFileCallName, func(token string) []any {
+		data := map[string]dbus.Variant{
+			"handle_token": convert.FromString(token),
+		}
+		if options != nil {
+			data["modal"] = convert.FromBool(!options.NotModal)
 
-	return readURIFromResponse(result.(dbus.ObjectPath))
+			if options.AcceptLabel != "" {
+				data["accept_label"] = convert.FromString(options.AcceptLabel)
+			}
+			if len(options.Filters) > 0 {
+				data["filters"] = dbus.MakeVariant(options.Filters)
+			}
+			if options.CurrentFilter != nil {
+				data["current_filter"] = dbus.MakeVariant(options.CurrentFilter)
+			}
+			if len(options.Choices) > 0 {
+				data["choices"] = dbus.MakeVariant(options.Choices)
+			}
+			if options.CurrentName != "" {
+				data["current_name"] = convert.FromString(options.CurrentName)
+			}
+			if options.CurrentFolder != "" {
+				data["current_folder"] = convert.ToNullTerminatedValue(options.CurrentFolder)
+			}
+		}
+
+		return []any{parentWindow, title, data}
+	})
 }
 
 // SaveFilesOptions contains the options for how files are saved.
@@ -80,42 +81,41 @@ type SaveFilesOptions struct {
 // SaveFiles opens a filechooser for selecting where to save one or more files.
 // The chooser will use the supplied title as it's name.
 func SaveFiles(parentWindow, title string, options *SaveFilesOptions) ([]string, error) {
-	data := map[string]dbus.Variant{}
+	return SaveFilesContext(context.Background(), parentWindow, title, options)
+}
 
+// SaveFilesContext is SaveFiles with a context.
+func SaveFilesContext(ctx context.Context, parentWindow, title string, options *SaveFilesOptions) ([]string, error) {
+	userToken := ""
 	if options != nil {
-		data = map[string]dbus.Variant{
-			"modal": convert.FromBool(!options.NotModal),
-		}
+		userToken = options.HandleToken
+	}
 
-		if options.HandleToken != "" {
-			data["handle_token"] = convert.FromString(options.HandleToken)
+	return callForURIs(ctx, userToken, saveFilesCallName, func(token string) []any {
+		data := map[string]dbus.Variant{
+			"handle_token": convert.FromString(token),
 		}
+		if options != nil {
+			data["modal"] = convert.FromBool(!options.NotModal)
 
-		if options.AcceptLabel != "" {
-			data["accept_label"] = convert.FromString(options.AcceptLabel)
-		}
-
-		if len(options.Choices) > 0 {
-			data["choices"] = dbus.MakeVariant(options.Choices)
-		}
-
-		if options.CurrentFolder != "" {
-			data["current_folder"] = convert.ToNullTerminatedValue(options.CurrentFolder)
-		}
-
-		if len(options.Files) > 0 {
-			files := make([][]byte, len(options.Files))
-			for i, file := range options.Files {
-				files[i] = convert.FromStringToNullTerminated(file)
+			if options.AcceptLabel != "" {
+				data["accept_label"] = convert.FromString(options.AcceptLabel)
 			}
-			data["files"] = dbus.MakeVariant(files)
+			if len(options.Choices) > 0 {
+				data["choices"] = dbus.MakeVariant(options.Choices)
+			}
+			if options.CurrentFolder != "" {
+				data["current_folder"] = convert.ToNullTerminatedValue(options.CurrentFolder)
+			}
+			if len(options.Files) > 0 {
+				files := make([][]byte, len(options.Files))
+				for i, file := range options.Files {
+					files[i] = convert.FromStringToNullTerminated(file)
+				}
+				data["files"] = dbus.MakeVariant(files)
+			}
 		}
-	}
 
-	result, err := apis.Call(saveFilesCallName, parentWindow, title, data)
-	if err != nil {
-		return nil, err
-	}
-
-	return readURIFromResponse(result.(dbus.ObjectPath))
+		return []any{parentWindow, title, data}
+	})
 }

--- a/internal/apis/changed.go
+++ b/internal/apis/changed.go
@@ -2,30 +2,40 @@ package apis
 
 import "github.com/godbus/dbus/v5"
 
-// ListenOnSignal returns a channel that outputs a values each time the given signal is sent.
-// It matches signals on the default portal object path.
-func ListenOnSignal(interfaceName, signalName string) (chan *dbus.Signal, error) {
+// ListenOnSignal subscribes to (interfaceName.signalName) on the default
+// portal object path. See ListenOnSignalAt.
+func ListenOnSignal(interfaceName, signalName string) (<-chan *dbus.Signal, func(), error) {
 	return ListenOnSignalAt(ObjectPath, interfaceName, signalName)
 }
 
-// ListenOnSignalAt returns a channel that outputs a value each time the given signal is sent
-// on the specified object path. Use this for signals emitted on request-specific or
-// session-specific paths rather than the base portal path.
-func ListenOnSignalAt(path dbus.ObjectPath, interfaceName, signalName string) (chan *dbus.Signal, error) {
+// ListenOnSignalAt subscribes to (interfaceName.signalName) on path. The
+// returned cleanup releases both the DBus match rule and the client-side
+// subscription; long-lived listeners may skip it.
+func ListenOnSignalAt(path dbus.ObjectPath, interfaceName, signalName string) (<-chan *dbus.Signal, func(), error) {
 	conn, err := dbus.SessionBus()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	if err := conn.AddMatchSignal(
+	matchOptions := []dbus.MatchOption{
 		dbus.WithMatchObjectPath(path),
 		dbus.WithMatchInterface(interfaceName),
 		dbus.WithMatchMember(signalName),
-	); err != nil {
-		return nil, err
+	}
+	if err := conn.AddMatchSignal(matchOptions...); err != nil {
+		return nil, nil, err
 	}
 
-	signal := make(chan *dbus.Signal)
-	conn.Signal(signal)
-	return signal, nil
+	ch, unsubscribe, err := SubscribeSignal(path, interfaceName, signalName)
+	if err != nil {
+		_ = conn.RemoveMatchSignal(matchOptions...)
+		return nil, nil, err
+	}
+
+	cleanup := func() {
+		unsubscribe()
+		_ = conn.RemoveMatchSignal(matchOptions...)
+	}
+
+	return ch, cleanup, nil
 }

--- a/internal/apis/router.go
+++ b/internal/apis/router.go
@@ -1,0 +1,97 @@
+package apis
+
+import (
+	"sync"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// Signal routing. godbus delivers every signal on the connection to every
+// channel registered via conn.Signal, which is wasteful for portal workloads
+// and prone to leaks when callers forget conn.RemoveSignal. We register one
+// channel with godbus and fan out here, keyed by (path, interface.member).
+
+type routerKey struct {
+	path dbus.ObjectPath
+	name string // interface.member
+}
+
+var (
+	routerInitMu sync.Mutex
+	routerReady  bool
+
+	routerMu   sync.Mutex
+	routerSubs = map[routerKey][]chan<- *dbus.Signal{}
+)
+
+func ensureRouter() error {
+	routerInitMu.Lock()
+	defer routerInitMu.Unlock()
+	if routerReady {
+		return nil
+	}
+
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return err
+	}
+
+	all := make(chan *dbus.Signal, 256)
+	conn.Signal(all)
+	go routerLoop(all)
+
+	routerReady = true
+	return nil
+}
+
+func routerLoop(in <-chan *dbus.Signal) {
+	for sig := range in {
+		key := routerKey{path: sig.Path, name: sig.Name}
+
+		// snapshot the subscriber list so we don't hold the lock while sending
+		routerMu.Lock()
+		targets := append([]chan<- *dbus.Signal(nil), routerSubs[key]...)
+		routerMu.Unlock()
+
+		for _, ch := range targets {
+			select {
+			case ch <- sig:
+			default: // slow subscriber, drop
+			}
+		}
+	}
+}
+
+func registerSubscriber(key routerKey, ch chan<- *dbus.Signal) (cleanup func()) {
+	routerMu.Lock()
+	routerSubs[key] = append(routerSubs[key], ch)
+	routerMu.Unlock()
+
+	return func() {
+		routerMu.Lock()
+		defer routerMu.Unlock()
+		subs := routerSubs[key]
+		for i, c := range subs {
+			if c == ch {
+				routerSubs[key] = append(subs[:i], subs[i+1:]...)
+				break
+			}
+		}
+		if len(routerSubs[key]) == 0 {
+			delete(routerSubs, key)
+		}
+	}
+}
+
+// SubscribeSignal returns a channel that receives signals matching
+// (path, interface.member), and a cleanup to unsubscribe. The caller is
+// still responsible for AddMatchSignal/RemoveMatchSignal so the bus
+// forwards the signals to this connection.
+func SubscribeSignal(path dbus.ObjectPath, interfaceName, memberName string) (<-chan *dbus.Signal, func(), error) {
+	if err := ensureRouter(); err != nil {
+		return nil, nil, err
+	}
+	key := routerKey{path: path, name: interfaceName + "." + memberName}
+	ch := make(chan *dbus.Signal, 4)
+	return ch, registerSubscriber(key, ch), nil
+}

--- a/internal/apis/router_integration_test.go
+++ b/internal/apis/router_integration_test.go
@@ -1,0 +1,54 @@
+//go:build integration
+// +build integration
+
+package apis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// Smoke-test the full subscribe+emit round-trip against a live session bus.
+// Run with:  go test -tags=integration ./internal/apis/...
+func TestSubscribeSignal_EndToEnd(t *testing.T) {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		t.Skipf("no session bus: %v", err)
+	}
+
+	const (
+		path   = dbus.ObjectPath("/rymdport/portal/test/router")
+		iface  = "com.rymdport.PortalTest.Router"
+		member = "Hello"
+	)
+	match := []dbus.MatchOption{
+		dbus.WithMatchObjectPath(path),
+		dbus.WithMatchInterface(iface),
+		dbus.WithMatchMember(member),
+	}
+	if err := conn.AddMatchSignal(match...); err != nil {
+		t.Fatalf("AddMatchSignal: %v", err)
+	}
+	defer conn.RemoveMatchSignal(match...)
+
+	ch, cleanup, err := SubscribeSignal(path, iface, member)
+	if err != nil {
+		t.Fatalf("SubscribeSignal: %v", err)
+	}
+	defer cleanup()
+
+	if err := conn.Emit(path, iface+"."+member, "world"); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	select {
+	case sig := <-ch:
+		if sig.Path != path || sig.Name != iface+"."+member {
+			t.Fatalf("unexpected signal: %+v", sig)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for signal round-trip")
+	}
+}

--- a/internal/apis/router_test.go
+++ b/internal/apis/router_test.go
@@ -1,0 +1,123 @@
+package apis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+)
+
+func resetRouter(t *testing.T) {
+	t.Helper()
+	routerMu.Lock()
+	defer routerMu.Unlock()
+	routerSubs = map[routerKey][]chan<- *dbus.Signal{}
+}
+
+func k(path dbus.ObjectPath, iface, member string) routerKey {
+	return routerKey{path: path, name: iface + "." + member}
+}
+
+// drive runs routerLoop against a set of incoming signals and blocks until it
+// drains. Helper so each test reads as a flat sequence.
+func drive(t *testing.T, sigs ...*dbus.Signal) {
+	t.Helper()
+	in := make(chan *dbus.Signal, len(sigs))
+	for _, s := range sigs {
+		in <- s
+	}
+	close(in)
+	done := make(chan struct{})
+	go func() { routerLoop(in); close(done) }()
+	<-done
+}
+
+func TestRouter_DeliversMatchingSignal(t *testing.T) {
+	resetRouter(t)
+
+	ch := make(chan *dbus.Signal, 1)
+	defer registerSubscriber(k("/p", "i.f", "M"), ch)()
+
+	drive(t, &dbus.Signal{Path: "/p", Name: "i.f.M", Body: []any{"hi"}})
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("signal not delivered")
+	}
+}
+
+// The router must filter by the full (path, interface.member) tuple; before
+// this change memorymonitor and settings were cross-delivering each other's
+// signals because they share the portal base path.
+func TestRouter_FiltersByFullKey(t *testing.T) {
+	resetRouter(t)
+
+	ch := make(chan *dbus.Signal, 4)
+	defer registerSubscriber(k("/a", "i.f", "M1"), ch)()
+
+	drive(t,
+		&dbus.Signal{Path: "/a", Name: "i.f.M2"},   // wrong member
+		&dbus.Signal{Path: "/a", Name: "other.M1"}, // wrong interface
+		&dbus.Signal{Path: "/b", Name: "i.f.M1"},   // wrong path
+		&dbus.Signal{Path: "/a", Name: "i.f.M1"},   // match
+	)
+
+	if got := len(ch); got != 1 {
+		t.Fatalf("got %d signals, want 1", got)
+	}
+}
+
+func TestRouter_CleanupRemovesOnlyOwnChannel(t *testing.T) {
+	resetRouter(t)
+
+	ch1 := make(chan *dbus.Signal, 1)
+	ch2 := make(chan *dbus.Signal, 1)
+	cleanup1 := registerSubscriber(k("/p", "i.f", "M"), ch1)
+	defer registerSubscriber(k("/p", "i.f", "M"), ch2)()
+
+	cleanup1()
+
+	drive(t, &dbus.Signal{Path: "/p", Name: "i.f.M"})
+
+	if len(ch1) != 0 {
+		t.Fatal("ch1 should be unsubscribed")
+	}
+	if len(ch2) != 1 {
+		t.Fatal("ch2 should still receive")
+	}
+}
+
+// Cleanup is invoked both explicitly on error paths and via defer, so it must
+// tolerate repeated calls.
+func TestRouter_CleanupIsIdempotent(t *testing.T) {
+	resetRouter(t)
+
+	cleanup := registerSubscriber(k("/p", "i.f", "M"), make(chan *dbus.Signal, 1))
+	cleanup()
+	cleanup()
+}
+
+// A slow subscriber must not block the router or starve other subscribers;
+// routerLoop uses a non-blocking send.
+func TestRouter_SlowSubscriberDropsInsteadOfBlocking(t *testing.T) {
+	resetRouter(t)
+
+	slow := make(chan *dbus.Signal) // unbuffered, never read
+	fast := make(chan *dbus.Signal, 4)
+	defer registerSubscriber(k("/p", "i.f", "M"), slow)()
+	defer registerSubscriber(k("/p", "i.f", "M"), fast)()
+
+	drive(t,
+		&dbus.Signal{Path: "/p", Name: "i.f.M"},
+		&dbus.Signal{Path: "/p", Name: "i.f.M"},
+		&dbus.Signal{Path: "/p", Name: "i.f.M"},
+	)
+
+	if len(fast) != 3 {
+		t.Fatalf("fast: got %d, want 3", len(fast))
+	}
+	if len(slow) != 0 {
+		t.Fatalf("slow: got %d, want 0 (dropped)", len(slow))
+	}
+}

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -1,52 +1,138 @@
-// Package request implements handling for the Request interface shared by all portal interfaces.
+// Package request implements the Request interface shared by portal methods
+// that return a handle and emit a Response signal asynchronously.
 package request
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+
 	"github.com/godbus/dbus/v5"
 	"github.com/rymdport/portal"
 	"github.com/rymdport/portal/internal/apis"
 )
 
+// https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html
 const (
 	interfaceName  = "org.freedesktop.portal.Request"
 	responseMember = "Response"
 	closeCallName  = interfaceName + ".Close"
+
+	requestPathPrefix = "/org/freedesktop/portal/desktop/request/"
 )
 
-// ResponseStatus contains the status of the response.
+// ResponseStatus of a portal Response signal.
 type ResponseStatus = uint32
 
 const (
-	Success   ResponseStatus = 0 // The request was carried out.
-	Cancelled ResponseStatus = 1 // The user cancelled the interaction.
-	Ended     ResponseStatus = 2 // The user interaction was ended in some other way.
+	Success   ResponseStatus = 0
+	Cancelled ResponseStatus = 1
+	Ended     ResponseStatus = 2 // closed by the system or other non-user reason
 )
 
-// Close closes the portal request to which this object refers and ends all related user interaction (dialogs, etc).
+// Response is the payload of a portal Request's Response signal.
+type Response struct {
+	Handle  dbus.ObjectPath
+	Status  ResponseStatus
+	Results map[string]dbus.Variant
+}
+
+// Close closes the portal Request at path.
 func Close(path dbus.ObjectPath) error {
 	return apis.CallOnObject(path, closeCallName)
 }
 
-// OnSignalResponse takes the given dbus connection and tries to read the response object.
-// This only works for dbus calls that have an associated response.
-func OnSignalResponse(path dbus.ObjectPath) (ResponseStatus, map[string]dbus.Variant, error) {
-	signal, err := apis.ListenOnSignalAt(path, interfaceName, responseMember)
+func generateToken() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("rymdport/portal: crypto/rand failed: " + err.Error())
+	}
+	return "rymdportal" + hex.EncodeToString(b[:])
+}
+
+// buildRequestPath is the Request path the portal will use for a call
+// made by sender with the given handle_token. See the spec link above.
+func buildRequestPath(sender, token string) dbus.ObjectPath {
+	if sender == "" {
+		return ""
+	}
+	sender = strings.TrimPrefix(sender, ":")
+	sender = strings.ReplaceAll(sender, ".", "_")
+	return dbus.ObjectPath(requestPathPrefix + sender + "/" + token)
+}
+
+func expectedHandle(conn *dbus.Conn, token string) dbus.ObjectPath {
+	names := conn.Names()
+	if len(names) == 0 {
+		return ""
+	}
+	return buildRequestPath(names[0], token)
+}
+
+// SendRequest dispatches a portal method that returns a Request handle and
+// waits for its Response signal. buildArgs receives the handle_token to
+// write into the call's options map; pass token="" to generate one.
+//
+// The Response subscription is installed before the call to avoid missing
+// the signal on fast backends. Cancelling ctx asks the portal to close the
+// Request (best-effort).
+func SendRequest(
+	ctx context.Context,
+	token, callName string,
+	buildArgs func(token string) []any,
+) (Response, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return Response{Status: Ended}, err
+	}
+
+	conn, err := dbus.SessionBus()
 	if err != nil {
-		return Ended, nil, err
+		return Response{Status: Ended}, err
 	}
 
-	for response := range signal {
-		if response.Path != path {
-			continue
-		}
-		if len(response.Body) != 2 {
-			return Ended, nil, portal.ErrUnexpectedResponse
-		}
+	if token == "" {
+		token = generateToken()
+	}
+	expected := expectedHandle(conn, token)
 
-		status := response.Body[0].(ResponseStatus)
-		results := response.Body[1].(map[string]dbus.Variant)
-		return status, results, nil
+	signal, cleanup, err := apis.ListenOnSignalAt(expected, interfaceName, responseMember)
+	if err != nil {
+		return Response{Status: Ended}, err
+	}
+	defer cleanup()
+
+	call := conn.Object(apis.ObjectName, apis.ObjectPath).Call(callName, 0, buildArgs(token)...)
+	if call.Err != nil {
+		return Response{Status: Ended}, call.Err
 	}
 
-	return Ended, nil, portal.ErrUnexpectedResponse
+	var handle dbus.ObjectPath
+	if err := call.Store(&handle); err != nil {
+		return Response{Status: Ended}, err
+	}
+
+	var sig *dbus.Signal
+	select {
+	case <-ctx.Done():
+		go func() { _ = Close(handle) }()
+		return Response{Handle: handle, Status: Ended}, ctx.Err()
+	case sig = <-signal:
+	}
+
+	if len(sig.Body) != 2 {
+		return Response{Handle: handle, Status: Ended}, portal.ErrUnexpectedResponse
+	}
+	status, ok := sig.Body[0].(ResponseStatus)
+	if !ok {
+		return Response{Handle: handle, Status: Ended}, portal.ErrUnexpectedResponse
+	}
+	results, ok := sig.Body[1].(map[string]dbus.Variant)
+	if !ok {
+		return Response{Handle: handle, Status: Ended}, portal.ErrUnexpectedResponse
+	}
+	return Response{Handle: handle, Status: status, Results: results}, nil
 }

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -1,0 +1,95 @@
+package request
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// TestBuildRequestPath guards the formula that makes pre-subscription safe:
+// if our path diverges from the one the portal picks, we listen to the
+// wrong signal and hang.
+func TestBuildRequestPath(t *testing.T) {
+	cases := []struct {
+		name   string
+		sender string
+		token  string
+		want   dbus.ObjectPath
+	}{
+		{"unique name", ":1.42", "rymdportalabc", "/org/freedesktop/portal/desktop/request/1_42/rymdportalabc"},
+		{"multiple dots", ":1.2.3", "t", "/org/freedesktop/portal/desktop/request/1_2_3/t"},
+		{"no leading colon", "1.42", "t", "/org/freedesktop/portal/desktop/request/1_42/t"},
+		{"double colon only one stripped", "::1.42", "t", "/org/freedesktop/portal/desktop/request/:1_42/t"},
+		{"empty sender", "", "t", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := buildRequestPath(tc.sender, tc.token); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Tokens end up as a DBus object path element, which only allows [A-Za-z0-9_].
+func TestGenerateToken_DBusPathSafe(t *testing.T) {
+	valid := regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+	for i := 0; i < 20; i++ {
+		if tok := generateToken(); !valid.MatchString(tok) {
+			t.Fatalf("invalid token: %q", tok)
+		}
+	}
+}
+
+// A context that is already done when SendRequest is entered must short-circuit
+// without touching the bus or calling buildArgs.
+func TestSendRequest_ContextAlreadyDone(t *testing.T) {
+	cases := []struct {
+		name string
+		ctx  func() (context.Context, context.CancelFunc)
+		want error
+	}{
+		{
+			"cancelled",
+			func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, func() {}
+			},
+			context.Canceled,
+		},
+		{
+			"deadline expired",
+			func() (context.Context, context.CancelFunc) {
+				return context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+			},
+			context.DeadlineExceeded,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := tc.ctx()
+			defer cancel()
+
+			called := false
+			resp, err := SendRequest(ctx, "", "com.example.Call", func(string) []any {
+				called = true
+				return nil
+			})
+
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want %v", err, tc.want)
+			}
+			if resp.Status != Ended {
+				t.Fatalf("Status = %d, want Ended", resp.Status)
+			}
+			if called {
+				t.Fatal("buildArgs must not run when ctx is already done")
+			}
+		})
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,4 +1,5 @@
-// Package session is a shared session interface between all portal interfaces that involve long lived sessions. When a method that creates a session is called, if successful, the reply will include a session handle (i.e. object path) for a Session object, which will stay alive for the duration of the session.
+// Package session is the Session interface shared by portal interfaces that
+// create long-lived sessions (location, usb, ...).
 package session
 
 import (
@@ -19,12 +20,12 @@ const (
 	closeCallName = interfaceName + ".Close"
 )
 
-// Close closes the portal session to which this object refers and ends all related user interaction (dialogs, etc).
+// Close closes the portal session at path.
 func Close(path dbus.ObjectPath) error {
 	return apis.CallOnObject(path, closeCallName)
 }
 
-// GenerateToken generates a random token string prefixed with "rymdportal".
+// GenerateToken returns a random token prefixed with "rymdportal".
 func GenerateToken() dbus.Variant {
 	str := strings.Builder{}
 	str.WriteString("rymdportal")
@@ -33,26 +34,32 @@ func GenerateToken() dbus.Variant {
 	return convert.FromString(str.String())
 }
 
-// OnSignalClosed takes the given dbus connection and listens for the closed signal.
-// The signal is emitted when a session is closed.
-// The content of details is specified by the interface creating the session.
-func OnSignalClosed(path dbus.ObjectPath) (map[string]dbus.Variant, error) {
-	signal, err := apis.ListenOnSignalAt(path, interfaceName, closedMember)
+// OnSignalClosed blocks until the session emits Closed or done is closed.
+// Returns (nil, nil) on cancellation. Pass a nil done to wait forever.
+func OnSignalClosed(path dbus.ObjectPath, done <-chan struct{}) (map[string]dbus.Variant, error) {
+	signal, cleanup, err := apis.ListenOnSignalAt(path, interfaceName, closedMember)
 	if err != nil {
 		return nil, err
 	}
+	defer cleanup()
 
-	for response := range signal {
-		if response.Path != path {
-			continue
-		}
-		if len(response.Body) != 1 {
+	var response *dbus.Signal
+	select {
+	case <-done:
+		return nil, nil
+	case r, ok := <-signal:
+		if !ok {
 			return nil, portal.ErrUnexpectedResponse
 		}
-
-		details := response.Body[0].(map[string]dbus.Variant)
-		return details, nil
+		response = r
 	}
 
-	return nil, portal.ErrUnexpectedResponse
+	if len(response.Body) != 1 {
+		return nil, portal.ErrUnexpectedResponse
+	}
+	details, ok := response.Body[0].(map[string]dbus.Variant)
+	if !ok {
+		return nil, portal.ErrUnexpectedResponse
+	}
+	return details, nil
 }

--- a/location/session.go
+++ b/location/session.go
@@ -1,6 +1,8 @@
 package location
 
 import (
+	"context"
+
 	"github.com/godbus/dbus/v5"
 	"github.com/rymdport/portal/internal/apis"
 	"github.com/rymdport/portal/internal/convert"
@@ -18,38 +20,66 @@ type StartOptions struct {
 	HandleToken string
 }
 
-// Session is the value for a created location session.
-// The zero value is not usable.
+// Session is a location session. The zero value is not usable; obtain one
+// from CreateSession.
 type Session struct {
-	path dbus.ObjectPath
+	path     dbus.ObjectPath
+	done     chan struct{} // closed by Close to stop listeners
+	cleanups []func()
 }
 
-// Close closes the current session.
+// Close releases listener goroutines and closes the portal session.
 func (s *Session) Close() error {
+	if s.done != nil {
+		select {
+		case <-s.done: // already closed
+		default:
+			close(s.done)
+		}
+	}
+	for _, c := range s.cleanups {
+		c()
+	}
+	s.cleanups = nil
 	return session.Close(s.path)
 }
 
-// SetOnClosed sets a callback to run when the session is closed by the portal.
+// SetOnClosed sets a callback to run when the portal closes the session.
+// The goroutine exits on Close even if the signal never arrives.
 func (s *Session) SetOnClosed(callback func(error)) {
+	done := s.ensureDone()
 	go func() {
-		_, err := session.OnSignalClosed(s.path)
+		_, err := session.OnSignalClosed(s.path, done)
+		select {
+		case <-done:
+			return // cancelled by Close
+		default:
+		}
 		callback(err)
 	}()
 }
 
 // SetOnLocationUpdated sets a callback to run when the location changes.
+// The listener runs until Close is called.
 func (s *Session) SetOnLocationUpdated(callback func(Location)) error {
-	signal, err := apis.ListenOnSignalAt(s.path, interfaceName, locationUpdatedMember)
+	signal, cleanup, err := apis.ListenOnSignalAt(s.path, interfaceName, locationUpdatedMember)
 	if err != nil {
 		return err
 	}
+	s.cleanups = append(s.cleanups, cleanup)
+	done := s.ensureDone()
 
 	go func() {
-		for trigger := range signal {
+		for {
+			var trigger *dbus.Signal
+			select {
+			case <-done:
+				return
+			case trigger = <-signal:
+			}
 			if len(trigger.Body) != 2 {
 				continue
 			}
-
 			if path, ok := trigger.Body[0].(dbus.ObjectPath); !ok || path != s.path {
 				continue
 			}
@@ -70,19 +100,29 @@ func (s *Session) SetOnLocationUpdated(callback func(Location)) error {
 	return nil
 }
 
-// Start the location session. An application can only attempt start a session once.
+func (s *Session) ensureDone() chan struct{} {
+	if s.done == nil {
+		s.done = make(chan struct{})
+	}
+	return s.done
+}
+
+// Start the location session. An application can only start a session once.
 func (s *Session) Start(parentWindow string, options *StartOptions) error {
-	data := map[string]dbus.Variant{}
+	return s.StartContext(context.Background(), parentWindow, options)
+}
+
+// StartContext is Start with a context.
+func (s *Session) StartContext(ctx context.Context, parentWindow string, options *StartOptions) error {
+	userToken := ""
 	if options != nil {
-		data["HandleToken"] = convert.FromString(options.HandleToken)
+		userToken = options.HandleToken
 	}
-
-	result, err := apis.Call(startCallName, s.path, parentWindow, data)
-	if err != nil {
-		return err
-	}
-
-	path := result.(dbus.ObjectPath)
-	_, _, err = request.OnSignalResponse(path)
+	_, err := request.SendRequest(ctx, userToken, startCallName, func(token string) []any {
+		data := map[string]dbus.Variant{
+			"handle_token": convert.FromString(token),
+		}
+		return []any{s.path, parentWindow, data}
+	})
 	return err
 }

--- a/memorymonitor/warning.go
+++ b/memorymonitor/warning.go
@@ -13,8 +13,11 @@ type LowMemoryWarning struct {
 // Signal is emitted when a particular low memory situation happens,
 // with 0 being the lowest level of memory availability warning,
 // and 255 being the highest.
+//
+// This function blocks for the lifetime of the subscription; the
+// subscription is released only when the process exits.
 func OnSignalLowMemoryWarning(callback func(warning LowMemoryWarning)) error {
-	signal, err := apis.ListenOnSignal(interfaceName, "LowMemoryWarning")
+	signal, _, err := apis.ListenOnSignal(interfaceName, "LowMemoryWarning")
 	if err != nil {
 		return err
 	}

--- a/networkmonitor/changed.go
+++ b/networkmonitor/changed.go
@@ -5,8 +5,11 @@ import (
 )
 
 // OnSignalChanged calls the passed function when the network configuration changes.
+//
+// This function blocks for the lifetime of the subscription; the subscription
+// is released only when the process exits.
 func OnSignalChanged(callback func()) error {
-	signal, err := apis.ListenOnSignal(interfaceName, "changed")
+	signal, _, err := apis.ListenOnSignal(interfaceName, "changed")
 	if err != nil {
 		return err
 	}

--- a/screenshot/picker.go
+++ b/screenshot/picker.go
@@ -1,11 +1,12 @@
 package screenshot
 
 import (
+	"context"
 	"image/color"
 	"math"
 
 	"github.com/godbus/dbus/v5"
-	"github.com/rymdport/portal/internal/apis"
+	"github.com/rymdport/portal/internal/convert"
 	"github.com/rymdport/portal/internal/request"
 )
 
@@ -18,24 +19,32 @@ type PickerOptions struct {
 
 // PickColor obtains the color of a single pixel.
 func PickColor(parentWindow string, options *PickerOptions) (*color.RGBA, error) {
-	data := map[string]dbus.Variant{}
-	if options != nil && options.HandleToken != "" {
-		data["handleToken"] = dbus.MakeVariant(options.HandleToken)
+	return PickColorContext(context.Background(), parentWindow, options)
+}
+
+// PickColorContext is PickColor with a context.
+func PickColorContext(ctx context.Context, parentWindow string, options *PickerOptions) (*color.RGBA, error) {
+	userToken := ""
+	if options != nil {
+		userToken = options.HandleToken
 	}
 
-	result, err := apis.Call(pickColorCallName, parentWindow, data)
+	resp, err := request.SendRequest(ctx, userToken, pickColorCallName, func(token string) []any {
+		data := map[string]dbus.Variant{
+			"handle_token": convert.FromString(token),
+		}
+		return []any{parentWindow, data}
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	status, results, err := request.OnSignalResponse(result.(dbus.ObjectPath))
-	if err != nil {
-		return nil, err
-	} else if status == request.Cancelled {
+	} else if resp.Status == request.Cancelled {
 		return nil, nil
 	}
 
-	components := results["color"].Value().([]any)
+	components, ok := resp.Results["color"].Value().([]any)
+	if !ok || len(components) < 3 {
+		return nil, nil
+	}
 	red := math.Round(math.Max(0.0, math.Min(1.0, components[0].(float64))) * 255)
 	green := math.Round(math.Max(0.0, math.Min(1.0, components[1].(float64))) * 255)
 	blue := math.Round(math.Max(0.0, math.Min(1.0, components[2].(float64))) * 255)

--- a/screenshot/screenshot.go
+++ b/screenshot/screenshot.go
@@ -3,6 +3,8 @@
 package screenshot
 
 import (
+	"context"
+
 	"github.com/godbus/dbus/v5"
 
 	"github.com/rymdport/portal/internal/apis"
@@ -24,27 +26,33 @@ type ScreenshotOptions struct {
 
 // Screenshot takes a screenshot, and returns the result path as a string.
 func Screenshot(parentWindow string, options *ScreenshotOptions) (string, error) {
-	data := map[string]dbus.Variant{}
+	return ScreenshotContext(context.Background(), parentWindow, options)
+}
+
+// ScreenshotContext is like [Screenshot] but accepts a [context.Context] that
+// can be used to cancel the request.
+func ScreenshotContext(ctx context.Context, parentWindow string, options *ScreenshotOptions) (string, error) {
+	userToken := ""
 	if options != nil {
-		data["modal"] = convert.FromBool(!options.NotModal)
-		data["interactive"] = convert.FromBool(options.Interactive)
-		if options.HandleToken != "" {
-			data["handle_token"] = convert.FromString(options.HandleToken)
+		userToken = options.HandleToken
+	}
+
+	resp, err := request.SendRequest(ctx, userToken, screenshotCallName, func(token string) []any {
+		data := map[string]dbus.Variant{
+			"handle_token": convert.FromString(token),
 		}
-	}
-
-	result, err := apis.Call(screenshotCallName, parentWindow, data)
+		if options != nil {
+			data["modal"] = convert.FromBool(!options.NotModal)
+			data["interactive"] = convert.FromBool(options.Interactive)
+		}
+		return []any{parentWindow, data}
+	})
 	if err != nil {
 		return "", err
-	}
-
-	status, results, err := request.OnSignalResponse(result.(dbus.ObjectPath))
-	if err != nil {
-		return "", err
-	} else if status >= request.Cancelled {
+	} else if resp.Status >= request.Cancelled {
 		return "", nil
 	}
 
-	uri := results["uri"].Value().(string)
+	uri, _ := resp.Results["uri"].Value().(string)
 	return uri, nil
 }

--- a/secret/retrieve.go
+++ b/secret/retrieve.go
@@ -1,10 +1,10 @@
 package secret
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/godbus/dbus/v5"
-	"github.com/rymdport/portal/internal/apis"
 	"github.com/rymdport/portal/internal/convert"
 	"github.com/rymdport/portal/internal/request"
 )
@@ -27,38 +27,41 @@ type RetrieveOptions struct {
 // The portal may return an additional identifier associated with the secret in the results.
 // In the next call of this method, the application shall provide a token element in options.
 func RetrieveSecret(fd uintptr, options *RetrieveOptions) (string, error) {
+	return RetrieveSecretContext(context.Background(), fd, options)
+}
+
+// RetrieveSecretContext is RetrieveSecret with a context.
+func RetrieveSecretContext(ctx context.Context, fd uintptr, options *RetrieveOptions) (string, error) {
 	unixFD, err := convert.UintptrToUnixFD(fd)
 	if err != nil {
 		return "", err
 	}
 
-	data := map[string]dbus.Variant{}
+	userToken := ""
 	if options != nil {
-		if options.HandleToken != "" {
-			data["handle_token"] = convert.FromString(options.HandleToken)
+		userToken = options.HandleToken
+	}
+
+	resp, err := request.SendRequest(ctx, userToken, retrieveSecretCallName, func(token string) []any {
+		data := map[string]dbus.Variant{
+			"handle_token": convert.FromString(token),
 		}
-		if options.Token != "" {
+		if options != nil && options.Token != "" {
 			data["token"] = convert.FromString(options.Token)
 		}
-	}
-
-	result, err := apis.Call(retrieveSecretCallName, unixFD, data)
+		return []any{unixFD, data}
+	})
 	if err != nil {
 		return "", err
-	}
-
-	path := result.(dbus.ObjectPath)
-	status, results, err := request.OnSignalResponse(path)
-	if err != nil {
-		return "", err
-	} else if status > request.Success {
+	} else if resp.Status > request.Success {
 		return "", nil
 	}
 
-	if token, ok := results["token"]; ok {
-		return token.Value().(string), nil
-	} else if len(results) != 0 {
-		fmt.Println("Please contribute this information to rymdport/portal: ", results)
+	if token, ok := resp.Results["token"]; ok {
+		value, _ := token.Value().(string)
+		return value, nil
+	} else if len(resp.Results) != 0 {
+		fmt.Println("Please contribute this information to rymdport/portal: ", resp.Results)
 	}
 
 	return "", nil

--- a/settings/changed.go
+++ b/settings/changed.go
@@ -14,8 +14,11 @@ type Changed struct {
 
 // OnSignalSettingChanged listens for the SettingChanged signal.
 // This signal is emitted when a setting changes.
+//
+// This function blocks for the lifetime of the subscription; the subscription
+// is released only when the process exits.
 func OnSignalSettingChanged(callback func(changed Changed)) error {
-	signal, err := apis.ListenOnSignal(interfaceName, "SettingChanged")
+	signal, _, err := apis.ListenOnSignal(interfaceName, "SettingChanged")
 	if err != nil {
 		return err
 	}

--- a/usb/acquire.go
+++ b/usb/acquire.go
@@ -1,9 +1,10 @@
 package usb
 
 import (
+	"context"
+
 	"github.com/godbus/dbus/v5"
 
-	"github.com/rymdport/portal/internal/apis"
 	"github.com/rymdport/portal/internal/convert"
 	"github.com/rymdport/portal/internal/request"
 )
@@ -27,6 +28,11 @@ type dbusAcquireDevice struct {
 //
 // The org.freedesktop.portal.Request::Response signal is emitted without any extra information.
 func AcquireDevices(parentWindow string, options []AcquireDeviceOptions) (dbus.ObjectPath, error) {
+	return AcquireDevicesContext(context.Background(), parentWindow, options)
+}
+
+// AcquireDevicesContext is AcquireDevices with a context.
+func AcquireDevicesContext(ctx context.Context, parentWindow string, options []AcquireDeviceOptions) (dbus.ObjectPath, error) {
 	devices := make([]dbusAcquireDevice, len(options))
 	for i, dev := range options {
 		opts := map[string]dbus.Variant{}
@@ -40,19 +46,17 @@ func AcquireDevices(parentWindow string, options []AcquireDeviceOptions) (dbus.O
 		}
 	}
 
-	data := map[string]dbus.Variant{}
-
-	result, err := apis.Call(acquireDevicesCallName, parentWindow, devices, data)
+	resp, err := request.SendRequest(ctx, "", acquireDevicesCallName, func(token string) []any {
+		data := map[string]dbus.Variant{
+			"handle_token": convert.FromString(token),
+		}
+		return []any{parentWindow, devices, data}
+	})
 	if err != nil {
 		return "", err
-	}
-
-	status, _, err := request.OnSignalResponse(result.(dbus.ObjectPath))
-	if err != nil {
-		return "", err
-	} else if status >= request.Cancelled {
+	} else if resp.Status >= request.Cancelled {
 		return "", nil
 	}
 
-	return result.(dbus.ObjectPath), nil
+	return resp.Handle, nil
 }

--- a/usb/session.go
+++ b/usb/session.go
@@ -9,46 +9,73 @@ import (
 const deviceEventsMember = "DeviceEvents"
 
 // DeviceEvent represents a USB device event.
-// Each element of the events array is composed of the following fields.
 type DeviceEvent struct {
-	Action string           // Type of event that occurred. One of "add", "change", or "remove".
-	ID     string           // Device ID that the event occurred on.
-	Device DeviceProperties // Device properties attached to the ID. See EnumerateDevices for a list of all the properties that may be present in the vardict.
+	Action string           // "add", "change", or "remove"
+	ID     string           // device ID
+	Device DeviceProperties // device properties; see EnumerateDevices
 }
 
-// Session is the value for a created USB monitoring session.
-// The zero value is not usable.
+// Session is a USB monitoring session. The zero value is not usable; obtain
+// one from CreateSession.
 type Session struct {
-	path dbus.ObjectPath
+	path     dbus.ObjectPath
+	done     chan struct{} // closed by Close to stop listeners
+	cleanups []func()
 }
 
-// Close closes the current session.
+// Close releases listener goroutines and closes the portal session.
 func (s *Session) Close() error {
+	if s.done != nil {
+		select {
+		case <-s.done: // already closed
+		default:
+			close(s.done)
+		}
+	}
+	for _, c := range s.cleanups {
+		c()
+	}
+	s.cleanups = nil
 	return session.Close(s.path)
 }
 
-// SetOnClosed sets a callback to run when the session is closed by the portal.
+// SetOnClosed sets a callback to run when the portal closes the session.
+// The goroutine exits on Close even if the signal never arrives.
 func (s *Session) SetOnClosed(callback func(error)) {
+	done := s.ensureDone()
 	go func() {
-		_, err := session.OnSignalClosed(s.path)
+		_, err := session.OnSignalClosed(s.path, done)
+		select {
+		case <-done:
+			return // cancelled by Close
+		default:
+		}
 		callback(err)
 	}()
 }
 
 // SetOnDeviceEvents sets a callback to run when one or more USB devices have been added, changed, or removed.
 // The DeviceEvents signal is only emitted for active sessions created with CreateSession.
+// The listener runs until Close is called.
 func (s *Session) SetOnDeviceEvents(callback func([]DeviceEvent)) error {
-	signal, err := apis.ListenOnSignalAt(s.path, interfaceName, deviceEventsMember)
+	signal, cleanup, err := apis.ListenOnSignalAt(s.path, interfaceName, deviceEventsMember)
 	if err != nil {
 		return err
 	}
+	s.cleanups = append(s.cleanups, cleanup)
+	done := s.ensureDone()
 
 	go func() {
-		for trigger := range signal {
+		for {
+			var trigger *dbus.Signal
+			select {
+			case <-done:
+				return
+			case trigger = <-signal:
+			}
 			if len(trigger.Body) != 2 {
 				continue
 			}
-
 			if path, ok := trigger.Body[0].(dbus.ObjectPath); !ok || path != s.path {
 				continue
 			}
@@ -62,9 +89,15 @@ func (s *Session) SetOnDeviceEvents(callback func([]DeviceEvent)) error {
 					Device: raw[2].(map[string]dbus.Variant),
 				}
 			}
-
 			callback(events)
 		}
 	}()
 	return nil
+}
+
+func (s *Session) ensureDone() chan struct{} {
+	if s.done == nil {
+		s.done = make(chan struct{})
+	}
+	return s.done
 }

--- a/wallpaper/file.go
+++ b/wallpaper/file.go
@@ -1,23 +1,22 @@
 package wallpaper
 
 import (
-	"github.com/godbus/dbus/v5"
-	"github.com/rymdport/portal/internal/apis"
+	"context"
+
 	"github.com/rymdport/portal/internal/convert"
 )
 
 // SetWallpaperFile sets wallpaper specified as a local file.
 func SetWallpaperFile(parentWindow string, fd uintptr, options *SetWallpaperOptions) error {
+	return SetWallpaperFileContext(context.Background(), parentWindow, fd, options)
+}
+
+// SetWallpaperFileContext is SetWallpaperFile with a context.
+func SetWallpaperFileContext(ctx context.Context, parentWindow string, fd uintptr, options *SetWallpaperOptions) error {
 	unixFD, err := convert.UintptrToUnixFD(fd)
 	if err != nil {
 		return err
 	}
 
-	data := dbusDataFromOptions(options)
-	result, err := apis.Call(setWallpaperFileCallName, parentWindow, unixFD, data)
-	if err != nil {
-		return err
-	}
-
-	return readStatusFromResponse(result.(dbus.ObjectPath))
+	return setWallpaper(ctx, setWallpaperFileCallName, []any{parentWindow, unixFD}, options)
 }

--- a/wallpaper/uri.go
+++ b/wallpaper/uri.go
@@ -1,18 +1,13 @@
 package wallpaper
 
-import (
-	"github.com/godbus/dbus/v5"
-	"github.com/rymdport/portal/internal/apis"
-)
+import "context"
 
 // SetWallpaperURI sets wallpaper specified as a URI.
 func SetWallpaperURI(parentWindow string, uri string, options *SetWallpaperOptions) error {
-	data := dbusDataFromOptions(options)
+	return SetWallpaperURIContext(context.Background(), parentWindow, uri, options)
+}
 
-	result, err := apis.Call(setWallpaperURICallName, parentWindow, uri, data)
-	if err != nil {
-		return err
-	}
-
-	return readStatusFromResponse(result.(dbus.ObjectPath))
+// SetWallpaperURIContext is SetWallpaperURI with a context.
+func SetWallpaperURIContext(ctx context.Context, parentWindow string, uri string, options *SetWallpaperOptions) error {
+	return setWallpaper(ctx, setWallpaperURICallName, []any{parentWindow, uri}, options)
 }

--- a/wallpaper/wallpaper.go
+++ b/wallpaper/wallpaper.go
@@ -2,6 +2,7 @@
 package wallpaper
 
 import (
+	"context"
 	"errors"
 
 	"github.com/godbus/dbus/v5"
@@ -31,27 +32,29 @@ type SetWallpaperOptions struct {
 	SetOn       Location // Where to set the wallpaper. Possible values are Background, Lockscreen, or Both constants
 }
 
-func dbusDataFromOptions(options *SetWallpaperOptions) map[string]dbus.Variant {
-	data := map[string]dbus.Variant{}
-	if options != nil {
-		data["show-preview"] = convert.FromBool(options.ShowPreview)
-
-		if options.SetOn != "" {
-			data["set-on"] = convert.FromString(string(options.SetOn))
+func setWallpaper(ctx context.Context, callName string, callArgs []any, options *SetWallpaperOptions) error {
+	resp, err := request.SendRequest(ctx, "", callName, func(token string) []any {
+		data := map[string]dbus.Variant{
+			"handle_token": convert.FromString(token),
 		}
-	}
-	return data
-}
+		if options != nil {
+			data["show-preview"] = convert.FromBool(options.ShowPreview)
+			if options.SetOn != "" {
+				data["set-on"] = convert.FromString(string(options.SetOn))
+			}
+		}
 
-func readStatusFromResponse(path dbus.ObjectPath) error {
-	status, _, err := request.OnSignalResponse(path)
+		args := make([]any, 0, len(callArgs)+1)
+		args = append(args, callArgs...)
+		args = append(args, data)
+		return args
+	})
 	if err != nil {
 		return err
 	}
 
-	if status == request.Ended {
+	if resp.Status == request.Ended {
 		return errors.New("operation cancelled by system")
 	}
-
 	return nil
 }


### PR DESCRIPTION
### Description

Fixes intermittent `ErrUnexpectedResponse` and hangs on fast portal backends (COSMIC, Hyprland, sometimes KDE).

Fixes #18.
Fixes Jacalz/rymdport#187.

#### The race

Portal methods that return a `Request` handle used to:

1. dispatch the method call,
2. receive the handle from the reply,
3. subscribe to `Response` on that handle,
4. wait.

Between 2 and 3 the backend can already emit `Response`. The signal is then dropped and the caller hangs or returns `ErrUnexpectedResponse`. The spec documents this and specifies a deterministic Request path exactly so clients can subscribe first:  <https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html>

#### Fix

New `internal/request.SendRequest` computes the expected path from a `handle_token`, subscribes to `Response`, **then** dispatches the method call.

#### Why rename `OnSignalResponse` to `SendRequest`

The old `OnSignalResponse(path)` only listens. It takes a path that somebody else already got from the method reply, subscribes to `Response` on it, and returns when the signal arrives. That is all.

The new function does three things in one call: it computes the expected Request path from a `handle_token`, subscribes *before* issuing the method call, dispatches the call, and then waits for `Response`. The whole round-trip is inside one function because that is the only way to close the race: only the function that owns the dispatch can subscribe before it.

The portal spec calls this "sending a Request", which is also the natural English name for what the code does, so `SendRequest` fits. Keeping `OnSignalResponse` would have been misleading in two ways:

1. `OnSignal…` reads like a passive listener (`OnClick`, `OnResize`), but the function now owns the method call.
2. The input is no longer a `path`, it is a `callName` plus an option-builder, so even the parameter list no longer matches the old name.

`OnSignalResponse` is internal, so renaming (and removing the old one) does not break any external callers.

#### Why the diff is this large

One behaviour change, but it pulls in three dependent cleanups:

- **`handle_token` is now mandatory.** The pre-subscription path is derived from it, so every callsite had to be rewritten to always include it. While doing that I noticed `screenshot.PickColor` and `(*location.Session).Start` were sending `handleToken` / `HandleToken` instead of `handle_token` and silently losing user-supplied values. Fixed.

- **Signal plumbing reworked.** With many concurrent portal calls, the old `conn.Signal(ch)` fan-out delivered every signal to every channel and leaked channels that were never removed. Added a small router in `internal/apis` keyed by `(path, interface.member)` so each caller only sees its own signals and cleanups actually unregister. This also fixes `memorymonitor` and `settings` cross-delivering each other's signals.

- **`*Context` variants added.** Once `SendRequest` exists it's trivial to let it take a `context.Context`, so I added `OpenFileContext`, `ScreenshotContext` etc. for every Request-returning call. Cancelling the context asks the portal to close the dialog. Existing functions keep their signatures and delegate with `context.Background()`.

And `(*location.Session).Close` / `(*usb.Session).Close` now stop the `SetOn*` listener goroutines instead of leaking them.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.